### PR TITLE
Adds 'caddy:80' back to the server name

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,3 @@
 COMPOSE_PROJECT_NAME=projektor
 
-SERVER_NAME=projektor.localhost
+SERVER_NAME="projektor.localhost, caddy:80"


### PR DESCRIPTION
This allows the PWA to be able to connect internally to the API.

This is included in the default value, but I hadn't spotted that when I added the override.